### PR TITLE
 fix(audit): Allow user responses after TAT expiry & send auto email

### DIFF
--- a/audit_management/audit_management/doctype/my_audits/my_audits.js
+++ b/audit_management/audit_management/doctype/my_audits/my_audits.js
@@ -335,15 +335,20 @@ frappe.ui.form.on("My Audits", {
       if (
         frm.doc.status === "Pending" &&
         ((frappe.session.user == frm.doc.bm_user_id &&
-          frm.doc.bm_user_status === "Pending") ||
+          (frm.doc.bm_user_status === "Pending" ||
+          frm.doc.bm_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.gm_user_id &&
-            frm.doc.gm_user_status === "Pending") ||
+            (frm.doc.gm_user_status === "Pending" ||
+            frm.doc.gm_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.hr_user_id &&
-            frm.doc.hr_user_status === "Pending") ||
+            (frm.doc.hr_user_status === "Pending" ||
+            frm.doc.hr_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.coo_user_id &&
-            frm.doc.coo_user_status === "Pending") ||
+            (frm.doc.coo_user_status === "Pending" ||
+            frm.doc.coo_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.ceo_user_id &&
-            frm.doc.ceo_user_status === "Pending"))
+            (frm.doc.ceo_user_status === "Pending" ||
+            frm.doc.ceo_user_status === "No Response")))
       ) {
         frm.trigger("show_sendResponse_btn");
       }
@@ -352,17 +357,23 @@ frappe.ui.form.on("My Audits", {
       if (
         frm.doc.status === "Pending" &&
         ((frappe.session.user == frm.doc.dh_user_id &&
-          frm.doc.dh_user_status === "Pending") ||
+          (frm.doc.dh_user_status === "Pending" ||
+          frm.doc.dh_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.com_user_id &&
-            frm.doc.com_user_status === "Pending") ||
+            (frm.doc.com_user_status === "Pending" ||
+            frm.doc.com_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.rm_user_id &&
-            frm.doc.rm_user_status === "Pending") ||
+            (frm.doc.rm_user_status === "Pending" ||
+            frm.doc.rm_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.rom_user_id &&
-            frm.doc.rom_user_status === "Pending") ||
+            (frm.doc.rom_user_status === "Pending" ||
+            frm.doc.rom_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.zm_user_id &&
-            frm.doc.zm_user_status === "Pending") ||
+            (frm.doc.zm_user_status === "Pending" ||
+            frm.doc.zm_user_status === "No Response")) ||
           (frappe.session.user == frm.doc.zom_user_id &&
-            frm.doc.zom_user_status === "Pending"))
+            (frm.doc.zom_user_status === "Pending" ||
+            frm.doc.zom_user_status === "No Response")))
       ) {
         frm.trigger("show_sendResponse_btn");
       }
@@ -370,22 +381,22 @@ frappe.ui.form.on("My Audits", {
       // jab DH||COM aur RM||ROM aur ZM||ZOM mese koi ek reply kre to dusre ko sendTOresponse ki button dikhane
       if (
         (frappe.session.user == frm.doc.dh_user_id &&
-          frm.doc.dh_user_status === "Pending" &&
+          (frm.doc.dh_user_status === "Pending" || frm.doc.dh_user_status === "No Response" ) &&
           frm.doc.com_user_status === "Responded") ||
         (frappe.session.user == frm.doc.com_user_id &&
-          frm.doc.com_user_status === "Pending" &&
+          (frm.doc.com_user_status === "Pending" || frm.doc.com_user_status === "No Response") &&
           frm.doc.dh_user_status === "Responded") ||
         (frappe.session.user == frm.doc.rm_user_id &&
-          frm.doc.rm_user_status === "Pending" &&
+          (frm.doc.rm_user_status === "Pending" || frm.doc.rm_user_status === "No Response") &&
           frm.doc.rom_user_status === "Responded") ||
         (frappe.session.user == frm.doc.rom_user_id &&
-          frm.doc.rom_user_status === "Pending" &&
+          (frm.doc.rom_user_status === "Pending" || frm.doc.rom_user_status === "No Response") &&
           frm.doc.rm_user_status === "Responded") ||
         (frappe.session.user == frm.doc.zm_user_id &&
-          frm.doc.zm_user_status === "Pending" &&
+          (frm.doc.zm_user_status === "Pending" || frm.doc.zm_user_status === "No Response") &&
           frm.doc.zom_user_status === "Responded") ||
         (frappe.session.user == frm.doc.zom_user_id &&
-          frm.doc.zom_user_status === "Pending" &&
+          (frm.doc.zom_user_status === "Pending" || frm.doc.zom_user_status === "No Response") &&
           frm.doc.zm_user_status === "Responded")
       ) {
         frm.trigger("show_sendResponse_btn");

--- a/audit_management/audit_management/doctype/my_audits/my_audits.json
+++ b/audit_management/audit_management/doctype/my_audits/my_audits.json
@@ -292,7 +292,7 @@
    "label": "<b>BM Response : </b>"
   },
   {
-   "depends_on": "eval:doc.bm_response_box != null || frappe.session.user==doc.bm_user_id && doc.status==\"Pending\" && doc.bm_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.bm_response_box != null || frappe.session.user==doc.bm_user_id && doc.status==\"Pending\" && (doc.bm_user_status==\"Pending\" || doc.bm_user_status===\"No Response\")",
    "fieldname": "bm_response_box",
    "fieldtype": "Small Text",
    "label": "BM response box"
@@ -303,13 +303,13 @@
    "label": "<b>DH &amp; COM Response :</b>"
   },
   {
-   "depends_on": "eval:doc.dh_response_box != null || frappe.session.user==doc.dh_user_id && doc.status==\"Pending\" && doc.dh_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.dh_response_box != null || frappe.session.user==doc.dh_user_id && doc.status==\"Pending\" && (doc.dh_user_status==\"Pending\" || doc.dh_user_status===\"No Response\")",
    "fieldname": "dh_response_box",
    "fieldtype": "Small Text",
    "label": "DH response box"
   },
   {
-   "depends_on": "eval:doc.com_response_box != null || frappe.session.user==doc.com_user_id && doc.status==\"Pending\" && doc.com_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.com_response_box != null || frappe.session.user==doc.com_user_id && doc.status==\"Pending\" && (doc.com_user_status==\"Pending\" || doc.com_user_status===\"No Response\")",
    "fieldname": "com_response_box",
    "fieldtype": "Small Text",
    "label": "COM response box "
@@ -324,7 +324,7 @@
    "label": "<b>RM &amp; ROM Response :</b>"
   },
   {
-   "depends_on": "eval:doc.rm_response_box != null || frappe.session.user==doc.rm_user_id && doc.status==\"Pending\" && doc.rm_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.rm_response_box != null || frappe.session.user==doc.rm_user_id && doc.status==\"Pending\" && (doc.rm_user_status==\"Pending\" || doc.rm_user_status===\"No Response\")",
    "fieldname": "rm_response_box",
    "fieldtype": "Small Text",
    "label": "RM response box "
@@ -334,7 +334,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.rom_response_box != null || frappe.session.user==doc.rom_user_id && doc.status==\"Pending\" && doc.rom_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.rom_response_box != null || frappe.session.user==doc.rom_user_id && doc.status==\"Pending\" && (doc.rom_user_status==\"Pending\" || doc.rom_user_status===\"No Response\")",
    "fieldname": "rom_response_box",
    "fieldtype": "Small Text",
    "label": "ROM response box "
@@ -345,7 +345,7 @@
    "label": "<b>ZM &amp; ZOM Response :</b>"
   },
   {
-   "depends_on": "eval:doc.zm_response_box != null || frappe.session.user==doc.zm_user_id && doc.status==\"Pending\" && doc.zm_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.zm_response_box != null || frappe.session.user==doc.zm_user_id && doc.status==\"Pending\" && (doc.zm_user_status==\"Pending\" || doc.zm_user_status===\"No Response\")",
    "fieldname": "zm_response_box",
    "fieldtype": "Small Text",
    "label": "ZM response box "
@@ -355,7 +355,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.zom_response_box != null || frappe.session.user==doc.zom_user_id && doc.status==\"Pending\" && doc.zom_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.zom_response_box != null || frappe.session.user==doc.zom_user_id && doc.status==\"Pending\" && (doc.zom_user_status==\"Pending\" || doc.zom_user_status===\"No Response\")",
    "fieldname": "zom_response_box",
    "fieldtype": "Small Text",
    "label": "ZOM response box "
@@ -387,19 +387,19 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.gm_response_box != null || frappe.session.user==doc.gm_user_id && doc.status==\"Pending\" && doc.gm_user_status==\"Pending\"",
+   "depends_on": "eval:doc.gm_response_box != null || frappe.session.user==doc.gm_user_id && doc.status==\"Pending\" && (doc.gm_user_status==\"Pending\" || doc.gm_user_status===\"No Response\")",
    "fieldname": "gm_response_box",
    "fieldtype": "Small Text",
    "label": "GM response box "
   },
   {
-   "depends_on": "eval:doc.coo_response_box != null || frappe.session.user==doc.coo_user_id && doc.status==\"Pending\" && doc.coo_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.coo_response_box != null || frappe.session.user==doc.coo_user_id && doc.status==\"Pending\" && (doc.coo_user_status==\"Pending\" || doc.coo_user_status===\"No Response\")",
    "fieldname": "coo_response_box",
    "fieldtype": "Small Text",
    "label": "COO response box "
   },
   {
-   "depends_on": "eval:doc.ceo_response_box != null || frappe.session.user==doc.ceo_user_id && doc.status==\"Pending\" && doc.ceo_user_status==\"Pending\" ",
+   "depends_on": "eval:doc.ceo_response_box != null || frappe.session.user==doc.ceo_user_id && doc.status==\"Pending\" && (doc.ceo_user_status==\"Pending\" || doc.ceo_user_status===\"No Response\")",
    "fieldname": "ceo_response_box",
    "fieldtype": "Small Text",
    "label": "CEO response box "
@@ -512,70 +512,70 @@
    "read_only_depends_on": "eval:!frappe.user.has_role(\"Audit Manager\")"
   },
   {
-   "depends_on": "eval:frappe.session.user==doc.bm_user_id && (doc.bm_user_status===\"Pending\" || doc.bm_user_status===\"Responded\" ) || (frappe.session.user!==doc.bm_user_id && doc.bm_attach_box != null )",
+   "depends_on": "eval:frappe.session.user==doc.bm_user_id && (doc.bm_user_status===\"Pending\" || doc.bm_user_status===\"Responded\" || doc.bm_user_status===\"No Response\") || (frappe.session.user!==doc.bm_user_id && doc.bm_attach_box != null )",
    "fieldname": "bm_attach_box",
    "fieldtype": "Attach",
    "label": "BM attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.bm_user_id && doc.bm_attach_box != null && doc.bm_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval: frappe.session.user==doc.dh_user_id && (doc.dh_user_status===\"Pending\" || doc.dh_user_status===\"Responded\") || (frappe.session.user!==doc.dh_user_id && doc.dh_attach_box != null)\n",
+   "depends_on": "eval: frappe.session.user==doc.dh_user_id && (doc.dh_user_status===\"Pending\" || doc.dh_user_status===\"Responded\" || doc.dh_user_status===\"No Response\") || (frappe.session.user!==doc.dh_user_id && doc.dh_attach_box != null)\n",
    "fieldname": "dh_attach_box",
    "fieldtype": "Attach",
    "label": "DH attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.dh_user_id && doc.dh_attach_box != null && doc.dh_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval: frappe.session.user==doc.com_user_id && (doc.com_user_status===\"Pending\" || doc.com_user_status===\"Responded\") || (frappe.session.user!==doc.com_user_id && doc.com_attach_box != null)\n",
+   "depends_on": "eval: frappe.session.user==doc.com_user_id && (doc.com_user_status===\"Pending\" || doc.com_user_status===\"Responded\" || doc.com_user_status===\"No Response\") || (frappe.session.user!==doc.com_user_id && doc.com_attach_box != null)\n",
    "fieldname": "com_attach_box",
    "fieldtype": "Attach",
    "label": "COM Attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.com_user_id && doc.com_attach_box != null && doc.com_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval: frappe.session.user==doc.rm_user_id && (doc.rm_user_status===\"Pending\" || doc.rm_user_status===\"Responded\") || (frappe.session.user!==doc.rm_user_id && doc.rm_attach_box != null)\n",
+   "depends_on": "eval: frappe.session.user==doc.rm_user_id && (doc.rm_user_status===\"Pending\" || doc.rm_user_status===\"Responded\" || doc.rm_user_status===\"No Response\") || (frappe.session.user!==doc.rm_user_id && doc.rm_attach_box != null)\n",
    "fieldname": "rm_attach_box",
    "fieldtype": "Attach",
    "label": "RM attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.rm_user_id && doc.rm_attach_box != null && doc.rm_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval: frappe.session.user==doc.rom_user_id && (doc.rom_user_status===\"Pending\" || doc.rom_user_status===\"Responded\") || (frappe.session.user!==doc.rom_user_id && doc.rom_attach_box != null)\n",
+   "depends_on": "eval: frappe.session.user==doc.rom_user_id && (doc.rom_user_status===\"Pending\" || doc.rom_user_status===\"Responded\" || doc.rom_user_status===\"No Response\") || (frappe.session.user!==doc.rom_user_id && doc.rom_attach_box != null)\n",
    "fieldname": "rom_attach_box",
    "fieldtype": "Attach",
    "label": "ROM attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.rom_user_id && doc.rom_attach_box != null && doc.rom_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval: frappe.session.user==doc.zm_user_id && (doc.zm_user_status===\"Pending\" || doc.zm_user_status===\"Responded\") || (frappe.session.user!==doc.zm_user_id && doc.zm_attach_box != null)\n",
+   "depends_on": "eval: frappe.session.user==doc.zm_user_id && (doc.zm_user_status===\"Pending\" || doc.zm_user_status===\"Responded\" || doc.zm_user_status===\"No Response\") || (frappe.session.user!==doc.zm_user_id && doc.zm_attach_box != null)\n",
    "fieldname": "zm_attach_box",
    "fieldtype": "Attach",
    "label": "ZM attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.zm_user_id && doc.zm_attach_box != null && doc.zm_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval: frappe.session.user==doc.zom_user_id && (doc.zom_user_status===\"Pending\" || doc.zom_user_status===\"Responded\") || (frappe.session.user!==doc.zom_user_id && doc.zom_attach_box != null)\n",
+   "depends_on": "eval: frappe.session.user==doc.zom_user_id && (doc.zom_user_status===\"Pending\" || doc.zom_user_status===\"Responded\" || doc.zom_user_status===\"No Response\") || (frappe.session.user!==doc.zom_user_id && doc.zom_attach_box != null)\n",
    "fieldname": "zom_attach_box",
    "fieldtype": "Attach",
    "label": "ZOM attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.zom_user_id && doc.zom_attach_box != null && doc.zom_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval:frappe.session.user==doc.gm_user_id && (doc.gm_user_status===\"Pending\" || doc.gm_user_status===\"Responded\" ) || (frappe.session.user!==doc.gm_user_id && doc.gm_attach_box != null )",
+   "depends_on": "eval:frappe.session.user==doc.gm_user_id && (doc.gm_user_status===\"Pending\" || doc.gm_user_status===\"Responded\" || doc.gm_user_status===\"No Response\") || (frappe.session.user!==doc.gm_user_id && doc.gm_attach_box != null )",
    "fieldname": "gm_attach_box",
    "fieldtype": "Attach",
    "label": "GM attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.gm_user_id && doc.gm_attach_box != null && doc.gm_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval: frappe.session.user==doc.coo_user_id && (doc.coo_user_status===\"Pending\" || doc.coo_user_status===\"Responded\") || (frappe.session.user!==doc.coo_user_id && doc.coo_attach_box != null)\n",
+   "depends_on": "eval: frappe.session.user==doc.coo_user_id && (doc.coo_user_status===\"Pending\" || doc.coo_user_status===\"Responded\" || doc.coo_user_status===\"No Response\") || (frappe.session.user!==doc.coo_user_id && doc.coo_attach_box != null)\n",
    "fieldname": "coo_attach_box",
    "fieldtype": "Attach",
    "label": "COO attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.coo_user_id && doc.coo_attach_box != null && doc.coo_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval: frappe.session.user==doc.ceo_user_id && (doc.ceo_user_status===\"Pending\" || doc.ceo_user_status===\"Responded\") || (frappe.session.user!==doc.ceo_user_id && doc.ceo_attach_box != null)\n",
+   "depends_on": "eval: frappe.session.user==doc.ceo_user_id && (doc.ceo_user_status===\"Pending\" || doc.ceo_user_status===\"Responded\" || doc.ceo_user_status===\"No Response\") || (frappe.session.user!==doc.ceo_user_id && doc.ceo_attach_box != null)\n",
    "fieldname": "ceo_attach_box",
    "fieldtype": "Attach",
    "label": "CEO attachment",
@@ -996,7 +996,7 @@
    "fieldname": "query_type",
    "fieldtype": "Select",
    "label": "Query Type",
-   "options": "\nBranch Compliance\nCritical Compliance",
+   "options": "\nAudit Report Compliance\nCritical Compliance",
    "reqd": 1
   },
   {
@@ -1081,14 +1081,14 @@
    "label": "<b>HR Response : </b>"
   },
   {
-   "depends_on": "eval:frappe.session.user==doc.hr_user_id && (doc.hr_user_status===\"Pending\" || doc.hr_user_status===\"Responded\" ) || (frappe.session.user!==doc.hr_user_id && doc.hr_attach_box != null )",
+   "depends_on": "eval:frappe.session.user==doc.hr_user_id && (doc.hr_user_status===\"Pending\" || doc.hr_user_status===\"Responded\" || doc.hr_user_status===\"No Response\") || (frappe.session.user!==doc.hr_user_id && doc.hr_attach_box != null )",
    "fieldname": "hr_attach_box",
    "fieldtype": "Attach",
    "label": "HR attachment",
    "read_only_depends_on": "eval:frappe.session.user!==doc.hr_user_id && doc.hr_attach_box != null && doc.hr_user_status===\"Responded\""
   },
   {
-   "depends_on": "eval:doc.hr_response_box != null || frappe.session.user==doc.hr_user_id && doc.status==\"Pending\" && doc.hr_user_status==\"Pending\"",
+   "depends_on": "eval:doc.hr_response_box != null || frappe.session.user==doc.hr_user_id && doc.status==\"Pending\" && (doc.hr_user_status==\"Pending\" || doc.hr_user_status===\"No Response\")",
    "fieldname": "hr_response_box",
    "fieldtype": "Small Text",
    "label": "HR response box "
@@ -1107,7 +1107,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-30 12:12:13.619087",
+ "modified": "2025-04-03 15:23:55.001205",
  "modified_by": "Administrator",
  "module": "Audit Management",
  "name": "My Audits",
@@ -1127,6 +1127,7 @@
    "write": 1
   }
  ],
+ "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [
@@ -1142,5 +1143,6 @@
    "color": "Red",
    "title": "Pending"
   }
- ]
+ ],
+ "track_changes": 1
 }

--- a/audit_management/audit_management/doctype/my_audits/my_audits.py
+++ b/audit_management/audit_management/doctype/my_audits/my_audits.py
@@ -3,8 +3,7 @@
 import re
 import frappe
 from frappe.model.document import Document
-from frappe.utils import now, time_diff_in_hours ,time_diff_in_seconds
-
+from frappe.utils import now
 class MyAudits(Document):
     pass
 
@@ -57,8 +56,8 @@ def get_status_tracker_html(docname):
         bm_color = "grey"
         bm_title = f"Stage 1 : Not sent to BM - {bm_name}"
     elif bm_status == "No Response":
-        bm_color = "#151515"
-        bm_title = f"Stage 1 : No Response from BM - {bm_name}"
+        bm_color = "#4b0a7d"
+        bm_title = f"Stage 1 : No Response from BM within TAT - {bm_name}"
     elif bm_status == "Skipped":
         bm_color = "#ffbe0b"
         bm_title = f"Stage 1 : Skipped - No BM set for {branch_name}"
@@ -78,8 +77,8 @@ def get_status_tracker_html(docname):
         dh_color = "grey"
         dh_title = f"Stage 2 : Not sent to DH - {dh_name}"
     elif dh_status == "No Response":
-        dh_color = "#151515"
-        dh_title = f"Stage 2 : No Response from DH - {dh_name}"
+        dh_color = "#4b0a7d"
+        dh_title = f"Stage 2 : No Response from DH within TAT - {dh_name}"
     elif dh_status == "Skipped":
         dh_color = "#ffbe0b"
         dh_title = f"Stage 2 : Skipped - No DH set for {branch_name}"
@@ -92,8 +91,8 @@ def get_status_tracker_html(docname):
         com_color = "grey"
         com_title = f"Stage 2 : Not sent to COM - {com_name}"
     elif com_status == "No Response":
-        com_color = "#151515"
-        com_title = f"Stage 2 : No Response from COM - {com_name}"
+        com_color = "#4b0a7d"
+        com_title = f"Stage 2 : No Response from COM within TAT - {com_name}"
     elif com_status == "Skipped":
         com_color = "#ffbe0b"
         com_title = f"Stage 2 : Skipped - No COM set for {branch_name}"
@@ -114,8 +113,8 @@ def get_status_tracker_html(docname):
         rm_color = "grey"
         rm_title = f"Stage 3 : Not sent to RM - {rm_name}"
     elif rm_status == "No Response":
-        rm_color = "#151515"
-        rm_title = f"Stage 3 : No Response from RM - {rm_name}"
+        rm_color = "#4b0a7d"
+        rm_title = f"Stage 3 : No Response from RM within TAT - {rm_name}"
     elif rm_status == "Skipped":
         rm_color = "#ffbe0b"
         rm_title = f"Stage 3 : Skipped - No RM set for {branch_name}"
@@ -128,8 +127,8 @@ def get_status_tracker_html(docname):
         rom_color = "grey"
         rom_title = f"Stage 3 : Not sent to ROM - {rom_name}"
     elif rom_status == "No Response":
-        rom_color = "#151515"
-        rom_title = f"Stage 3 : No Response from ROM - {rom_name}"
+        rom_color = "#4b0a7d"
+        rom_title = f"Stage 3 : No Response from ROM within TAT - {rom_name}"
     elif rom_status == "Skipped":
         rom_color = "#ffbe0b"
         rom_title = f"Stage 3 : Skipped - No ROM set for {branch_name}"
@@ -150,8 +149,8 @@ def get_status_tracker_html(docname):
         zm_color = "grey"
         zm_title = f"Stage 4 : Not sent to ZM - {zm_name}"
     elif zm_status == "No Response":
-        zm_color = "#151515"
-        zm_title = f"Stage 4 : No Response from ZM - {zm_name}"
+        zm_color = "#4b0a7d"
+        zm_title = f"Stage 4 : No Response from ZM within TAT - {zm_name}"
     elif zm_status == "Skipped":
         zm_color = "#ffbe0b"
         zm_title = f"Stage 4 : Skipped - No ZM set for {branch_name}"
@@ -164,8 +163,8 @@ def get_status_tracker_html(docname):
         zom_color = "grey"
         zom_title = f"Stage 4 : Not sent to ZOM - {zom_name}"
     elif zom_status == "No Response":
-        zom_color = "#151515"
-        zom_title = f"Stage 4 : No Response from ZOM - {zom_name}"
+        zom_color = "#4b0a7d"
+        zom_title = f"Stage 4 : No Response from ZOM within TAT - {zom_name}"
     elif zom_status == "Skipped":
         zom_color = "#ffbe0b"
         zom_title = f"Stage 4 : Skipped - No ZOM set for {branch_name}"
@@ -182,8 +181,8 @@ def get_status_tracker_html(docname):
         gm_color = "grey"
         gm_title = f"Stage 5 : Not sent to GM - {gm_name}"
     elif gm_status == "No Response":
-        gm_color = "#151515"
-        gm_title = f"Stage 5 : No Response from GM - {gm_name}"
+        gm_color = "#4b0a7d"
+        gm_title = f"Stage 5 : No Response from GM within TAT - {gm_name}"
     elif gm_status == "Skipped":
         gm_color = "#ffbe0b"
         gm_title = f"Stage 5 : Skipped - No GM set for {branch_name}"
@@ -200,8 +199,8 @@ def get_status_tracker_html(docname):
         hr_color = "grey"
         hr_title = f"Stage 5 : Not sent to HR - {hr_name}"
     elif hr_status == "No Response":
-        hr_color = "#151515"
-        hr_title = f"Stage 5 : No Response from HR - {hr_name}"
+        hr_color = "#4b0a7d"
+        hr_title = f"Stage 5 : No Response from HR within TAT - {hr_name}"
     elif hr_status == "Skipped":
         hr_color = "#ffbe0b"
         hr_title = f"Stage 5 : Skipped - No GM set for {branch_name}"
@@ -218,8 +217,8 @@ def get_status_tracker_html(docname):
         coo_color = "grey"
         coo_title = f"Stage 6 : Not sent to COO - {coo_name}"
     elif coo_status == "No Response":
-        coo_color = "#151515"
-        coo_title = f"Stage 6 : No Response from COO - {coo_name}"
+        coo_color = "#4b0a7d"
+        coo_title = f"Stage 6 : No Response from COO within TAT - {coo_name}"
     elif coo_status == "Skipped":
         coo_color = "#ffbe0b"
         coo_title = f"Stage 6 : Skipped - No COO set for {branch_name}"
@@ -236,8 +235,8 @@ def get_status_tracker_html(docname):
         ceo_color = "grey"
         ceo_title = f"Stage 7 : Not sent to CEO - {ceo_name}"
     elif ceo_status == "No Response":
-        ceo_color = "#151515"
-        ceo_title = f"Stage 7 : No Response from CEO - {ceo_name}"
+        ceo_color = "#4b0a7d"
+        ceo_title = f"Stage 7 : No Response from CEO within TAT - {ceo_name}"
     elif ceo_status == "Skipped":
         ceo_color = "#ffbe0b"
         ceo_title = f"Stage 7 : Skipped - No CEO set for {branch_name}"
@@ -344,46 +343,41 @@ def send_to_all(record):
         }
     return message  # Return the message containing timestamps
 
-import frappe
-from frappe.utils import now, time_diff_in_seconds
 
 @frappe.whitelist()
 def check_pending_tat():
-    """Check for pending statuses and trigger the next stage if the pending time exceeds the threshold."""
-
+    print("Checking pending TAT...")
+    
     def has_pending_exceeded(record, user_status_field, pending_time_field, now_time):
-        """Helper function to check if the pending time has exceeded the set threshold."""
+        print(f"Checking pending time for {user_status_field} in record {record.name}")
+        
         status = getattr(record, user_status_field)
         pending_time = getattr(record, pending_time_field)
         query_type = getattr(record, "query_type", None)
-
-        # Determine TAT based on conditions
+        
+        tat_time = 1 * 24 * 60
+        tat_day = "1 Day TAT"
+        
         if user_status_field == "bm_user_status":
             if query_type == "Audit Report Compliance":
-                tat_time = 15 * 24 * 60  # 15 days in minutes
+                tat_time = 15 * 24 * 60
                 tat_day = "15 Days then 1 Day TAT"
             elif query_type == "Critical Compliance":
-                tat_time = 1 * 24 * 60  # 1 day in minutes
+                tat_time = 1 * 24 * 60
                 tat_day = "1 Day TAT"
-            else:
-                tat_time = 1 * 24 * 60  # Default (1 day)
-                tat_day = "1 Day TAT"
-        else:
-            tat_time = 1 * 24 * 60  # Default (1 day)
-            tat_day = "1 Day TAT"
-
-        # Check if the pending time has exceeded the threshold
+        
         if status == "Pending" and pending_time:
-            time_diff_minutes = time_diff_in_seconds(now_time, pending_time) / 60  # Convert seconds to minutes
+            time_diff_minutes = frappe.utils.time_diff_in_seconds(now_time, pending_time) / 60
             if time_diff_minutes >= tat_time:
-                frappe.db.set_value("My Audits", record.name, "tat_day", tat_day, update_modified=False)
+                frappe.db.set_value("My Audits", record.name, "tat_day", tat_day)
+                print("True aaya")
                 return True
+        print("False aaya")
         return False
 
-    # Fetch current time
-    now_time = now()
-
-    # Fetch all records with any 'Pending' status
+    now_time = frappe.utils.now()
+    print(f"Current time: {now_time}")
+    
     pending_records = frappe.get_all(
         "My Audits",
         or_filters=[
@@ -399,96 +393,206 @@ def check_pending_tat():
             ["coo_user_status", "=", "Pending"],
             ["ceo_user_status", "=", "Pending"],
         ],
-        fields=[
-            "name", "query_type", "bm_user_status", "bm_pending_time", "dh_user_status", "dh_pending_time",
-            "com_user_status", "com_pending_time", "rm_user_status", "rm_pending_time",
-            "rom_user_status", "rom_pending_time", "zm_user_status", "zm_pending_time",
-            "zom_user_status", "zom_pending_time", "gm_user_status", "gm_pending_time",
-            "hr_user_status", "hr_pending_time","coo_user_status", "coo_pending_time",
-            "ceo_user_status", "ceo_pending_time"
-        ],
+        fields=["name","query_generated_by_name","query_generated_by_designation","query_generated_by_branch", "audit_query_subject_box", "query_type", "bm_user_status", "bm_pending_time", "bm_mail",
+                "dh_user_status", "dh_pending_time", "dh_mail", "com_user_status", "com_pending_time", "com_mail",
+                "rm_user_status", "rm_pending_time", "rm_mail", "rom_user_status", "rom_pending_time", "rom_mail",
+                "zm_user_status", "zm_pending_time", "zm_mail", "zom_user_status", "zom_pending_time", "zom_mail",
+                "gm_user_status", "gm_pending_time", "gm_mail", "hr_user_status", "hr_pending_time", "hr_mail",
+                "coo_user_status", "coo_pending_time", "coo_mail", "ceo_user_status", "ceo_pending_time", "ceo_mail"]
     )
-
-    updates = []  # Store updates for batch processing
-
-    # Level transition definitions
+    
+    print(f"Total pending records found: {len(pending_records)}")
+    
+    updates = []
+    emails = []
+    
     level_transitions = [
-        # BM level (no prior level)
-        ([("bm_user_status", "bm_pending_time")], 
-         [("dh_user_status", "dh_pending_time"), ("com_user_status", "com_pending_time")]),
-
-        # DH and COM level (depends on BM being completed)
-        ([("dh_user_status", "dh_pending_time"), ("com_user_status", "com_pending_time")],
-         [("rm_user_status", "rm_pending_time"), ("rom_user_status", "rom_pending_time")]),
-
-        # RM and ROM level
-        ([("rm_user_status", "rm_pending_time"), ("rom_user_status", "rom_pending_time")],
-         [("zm_user_status", "zm_pending_time"), ("zom_user_status", "zom_pending_time")]),
-
-        # ZM and ZOM level
-        ([("zm_user_status", "zm_pending_time"), ("zom_user_status", "zom_pending_time")],
-         [("gm_user_status", "gm_pending_time")]),
-
-        # GM level
-        ([("gm_user_status", "gm_pending_time")],
-         [("hr_user_status", "hr_pending_time")]),
-
-         # HR level
-        ([("hr_user_status", "hr_pending_time")],
-         [("coo_user_status", "coo_pending_time")]),
-
-        # COO level
-        ([("coo_user_status", "coo_pending_time")],
-         [("ceo_user_status", "ceo_pending_time")]),
-
-        # Last stage - CEO level (handle explicitly to set to "No Response" if TAT exceeded)
-        ([("ceo_user_status", "ceo_pending_time")], [])
+        {
+            "current": ["bm_user_status", "bm_pending_time", "bm_mail"],
+            "next": [
+                ["dh_user_status", "dh_pending_time", "dh_mail"],
+                ["com_user_status", "com_pending_time", "com_mail"]
+            ]
+        },
+        {
+            "current": ["dh_user_status", "dh_pending_time", "dh_mail", "com_user_status", "com_pending_time", "com_mail"],
+            "next": [
+                ["rm_user_status", "rm_pending_time", "rm_mail"],
+                ["rom_user_status", "rom_pending_time", "rom_mail"]
+            ]
+        },
+        {
+            "current": ["rm_user_status", "rm_pending_time", "rm_mail", "rom_user_status", "rom_pending_time", "rom_mail"],
+            "next": [
+                ["zm_user_status", "zm_pending_time", "zm_mail"],
+                ["zom_user_status", "zom_pending_time", "zom_mail"]
+            ]
+        },
+        {
+            "current": ["zm_user_status", "zm_pending_time", "zm_mail", "zom_user_status", "zom_pending_time", "zom_mail"],
+            "next": [
+                ["gm_user_status", "gm_pending_time", "gm_mail"]
+            ]
+        },
+        {
+            "current": ["gm_user_status", "gm_pending_time", "gm_mail"],
+            "next": [
+                ["hr_user_status", "hr_pending_time", "hr_mail"]
+            ]
+        },
+        {
+            "current": ["hr_user_status", "hr_pending_time", "hr_mail"],
+            "next": [
+                ["coo_user_status", "coo_pending_time", "coo_mail"]
+            ]
+        },
+        {
+            "current": ["coo_user_status", "coo_pending_time", "coo_mail"],
+            "next": [
+                ["ceo_user_status", "ceo_pending_time", "ceo_mail"]
+            ]
+        }
     ]
 
-    for record in pending_records:
-        for current_level, next_level in level_transitions:
-            # Check if all current statuses are pending and have exceeded the TAT
-            if all(
-                has_pending_exceeded(record, status_field, time_field, now_time)
-                for status_field, time_field in current_level
-            ):
-                # Set current statuses to "No Response"
-                for status_field, _ in current_level:
-                    # Only set "No Response" if the status_field is not one of the excluded fields
-                    if status_field not in ["hr_user_status", "coo_user_status", "ceo_user_status"]:
-                        updates.append({"name": record.name, "field": status_field, "value": "No Response"})
-
-                # Set next statuses to "Pending" with updated pending time
-                for next_status_field, next_pending_field in next_level:
-                    updates.append({"name": record.name, "field": next_status_field, "value": "Pending"})
-                    updates.append({"name": record.name, "field": next_pending_field, "value": now_time})
-
-    # Apply updates to the database
-    for update in updates:
-        frappe.db.set_value("My Audits", update["name"], update["field"], update["value"], update_modified=False)
-
-    frappe.db.commit()
-
-
-import frappe
-@frappe.whitelist()
-def sendmail():
-    recipients = [
-        'talib.s@sahayogmultistate.com',
-        'arshad.q@sahayogmultistate.com'
-    ]
-
-    context = {
-        "message": "Hello, this is a test email using a template!",  # Template me use hone wala message
+    dear_lines = {
+    "dh_user_status": "Dear {{ doc.dh_name }} & {{ doc.com_name }},<br />DH & COM of {{ doc.emp_branch }},<br /><br />",
+    "com_user_status": "Dear {{ doc.dh_name }} & {{ doc.com_name }},<br />DH & COM of {{ doc.emp_branch }},<br /><br />",
+    "rm_user_status": "Dear {{ doc.rm_name }} & {{ doc.rom_name }},<br />RM & ROM for {{ doc.emp_branch }},<br /><br />",
+    "rom_user_status": "Dear {{ doc.rm_name }} & {{ doc.rom_name }},<br />RM & ROM for {{ doc.emp_branch }},<br /><br />",
+    "zm_user_status": "Dear {{ doc.zm_name }} & {{ doc.zom_name }},<br />ZM & ZOM for {{ doc.emp_branch }},<br /><br />",
+    "zom_user_status": "Dear {{ doc.zm_name }} & {{ doc.zom_name }},<br />ZM & ZOM for {{ doc.emp_branch }},<br /><br />",
+    "gm_user_status": "Dear {{ doc.gm_name }},<br />GM for {{ doc.emp_branch }},<br /><br />",
+    "hr_user_status": "Dear {{ doc.hr_name }},<br />HR for {{ doc.emp_branch }},<br /><br />",
+    "coo_user_status": "Dear {{ doc.coo_name }},<br />COO for {{ doc.emp_branch }},<br /><br />",
+    "ceo_user_status": "Dear {{ doc.ceo_name }},<br />CEO for {{ doc.emp_branch }},<br /><br />",
     }
 
-    frappe.sendmail(
-        recipients=recipients,
-        subject="Test",  # ✅ Subject me "Test"
-        template="sending_mail",  # ✅ Template ka naam (path nahi dena hota)
-        args=context,
-    )
-    print("mail send successfully")
+    query_creator = f"""
+    <p>Name: {{doc.query_generated_by_name}}</p>
+    <p>Designation: {{doc.query_generated_by_designation}}</p>
+    <p>Branch: {{doc.query_generated_by_branch}}</p>
+    
+    """
+    
+
+    
+    # Loop through the transition
+    for record in pending_records:
+        print(f"Processing record: {record.name}")
+
+        # Iterate through the transitions
+        for transition in level_transitions:
+            current_level = transition["current"]
+            next_levels = transition["next"]
+
+            # 🔍 Find all "Pending" status fields in current_level
+            active_fields = []
+            skip_update = False  # Flag to check if we need to skip update
+
+            # Check for multiple "Pending" statuses in current level
+            for i in range(0, len(current_level), 3):
+                status_field = current_level[i]
+                # If status is "Pending", add to active_fields
+                if getattr(record, status_field) == "Pending":  
+                    active_fields.append(status_field)
+                elif getattr(record, status_field) == "Responded":  # If any status is "Responded", skip update
+                    skip_update = True
+                    break
+
+            if skip_update:
+                print(f"Skipping update for {record.name}, as one or more user statuses are 'Responded'.")
+                continue  # Skip if any status is "Responded" and move to the next record
+
+            # If we have active fields (multiple "Pending" statuses), update them
+            if active_fields:
+                print(f"Active Fields: {active_fields}")
+
+                # ✅ Check pending time only for the active fields
+                for active_field in active_fields:
+                    pending_time_field = current_level[current_level.index(active_field) + 1]
+
+                    # Call the has_pending_exceeded function to check if pending time is exceeded
+                    if has_pending_exceeded(record, active_field, pending_time_field, now_time):
+                        print(f"Pending time exceeded for {active_field}, updating...")
+
+                        # ✅ Update all "Pending" fields to "No Response"
+                        for field in active_fields:  # Iterate over all active fields
+                            updates.append({"name": record.name, "field": field, "value": "No Response"})
+                            print(f"Setting 'No Response' for {field} in record {record.name}")
+
+                        # ✅ Move to next level and set "Pending" for all active transitions
+                        for next_level in next_levels:
+                            # Extract user_status fields only (skip pending_time fields)
+                            user_status_fields = [next_level[i] for i in range(0, len(next_level), 2)]  # Taking only user_status fields
+
+                            print("User Status Fields:", user_status_fields)  # Debugging: Print extracted fields
+
+                            # Update only the user status fields
+                            for user_status_field in user_status_fields:
+                                if not user_status_field.endswith("_mail"):  # Ignore _mail fields
+                                    print(f"Setting 'Pending' for {user_status_field} in record {record.name}")  # Debugging
+                                    updates.append({"name": record.name, "field": user_status_field, "value": "Pending"})
+
+                            # Update the corresponding pending_time fields
+                            for i in range(1, len(next_level), 2):  # Taking only pending_time fields
+                                pending_time_field = next_level[i]
+                                print(f"Setting '{now_time}' for {pending_time_field} in record {record.name}")  # Debugging
+                                updates.append({"name": record.name, "field": pending_time_field, "value": now_time})
+
+                            # Generate dynamic greeting based on the next status field
+                            dear_line = dear_lines.get(next_level[0], "Dear Sir/Madam,<br /><br />")
+
+                            # Collect email recipients without duplicates
+                           # Collect email recipients without duplicates
+                            if len(next_level) > 2 and hasattr(record, next_level[2]):
+                                recipient = getattr(record, next_level[2])
+                                print(f"Extracted recipient from {next_level[2]}: {recipient}")  # Debugging: Print recipient
+
+                                if recipient and recipient not in emails:
+                                    emails.append(recipient)
+                                    print(f"Added {recipient} to email list.")  # Debugging: Confirm addition
+                    else:
+                        print(f"Pending time not exceeded for {active_field}, skipping update...")
+                        continue  # Skip if pending time is not exceeded
+
+                    # 🛑 Stop further processing for this record once an update is done
+                    break  # This break will now end the transition loop and go to the next record
+
+    # Sending a single email to all recipients
+    # Sending a single email to all recipients
+    if emails:
+        email_subject = f"For : {record.audit_query_subject_box}"
+        email_message = frappe.render_template(
+            "audit_management/templates/emails/audit_query.html",
+            {
+                "doc": record, 
+                "dear_line": dear_line, 
+                "query_creator": query_creator  # ✅ Query creator bhi pass kar diya
+            }
+        )
+
+        # Send email to all recipients at once
+        print(f"Sending email to recipients: {emails}")
+        frappe.sendmail(
+            recipients=emails,
+            subject=email_subject,
+            message=email_message
+        )
+        print("Email sending completed.")
+
+
+    # Commit the database updates
+    print("Updating database...")
+    if updates:
+        for update in updates:
+            if isinstance(update["field"], list):  # If it's a list, update fields individually
+                for field in update["field"]:
+                    frappe.db.set_value("My Audits", update["name"], field, update["value"])
+                    print("=========================")
+            else:
+                frappe.db.set_value("My Audits", update["name"], update["field"], update["value"])
+                print("=========================")
+
 
 #this was for testing
 @frappe.whitelist()

--- a/audit_management/templates/emails/audit_query.html
+++ b/audit_management/templates/emails/audit_query.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="description"
+      content="New Audit Query: Please review and respond promptly."
+    />
+    <title>Audit Query Mail</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        background-color: #f4f4f4;
+        margin: 0;
+        padding: 20px;
+      }
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        background-color: #fff;
+        padding: 20px;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      }
+      .header {
+        font-size: 20px;
+        font-weight: bold;
+        margin-bottom: 20px;
+      }
+      .content {
+        font-size: 14px;
+        line-height: 1.6;
+        color: #333;
+      }
+      .query-box {
+        width: 90%;
+        margin: 0 auto;
+        height: 150px;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        padding: 10px;
+        font-size: 14px;
+        line-height: 1.6;
+        background-color: #f9f9f9;
+        color: black;
+        overflow-y: auto;
+        pointer-events: none;
+      }
+      .button-container {
+        margin-top: 20px;
+        text-align: center;
+      }
+      .button {
+        display: inline-block;
+        background-color: #4caf50;
+        color: #fff;
+        padding: 10px 20px;
+        text-decoration: none;
+        border-radius: 5px;
+      }
+      .footer {
+        font-size: 12px;
+        color: #666;
+        text-align: center;
+        margin-top: 20px;
+        padding-top: 10px;
+        border-top: 1px solid #ddd;
+      }
+      @media (max-width: 600px) {
+        .container {
+          padding: 10px;
+        }
+        .header {
+          font-size: 18px;
+        }
+        .content {
+          font-size: 12px;
+        }
+        .button {
+          padding: 8px 16px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">Audit Query: {{ doc.name }}</div>
+      <div class="content">
+        {{ dear_line }}
+
+        A new audit query has been sent to you from the Audit Department. Please
+        review the query and respond
+        <span style="color: red">as soon as possible, within 24 hours</span>.
+        <br /><br />
+
+        <p><b>Audit Query:</b></p>
+        <div class="query-box">{{ doc.audit_query_box }}</div>
+        <br /><br />
+
+        Query Creator:<br />
+
+        {{ query_creator | safe }}
+      </div>
+
+      <div class="button-container">
+        <a
+          href="{{ 'http://mysahayog.com/app/my-audits/' + doc.name }}"
+          class="button"
+          target="_blank"
+          aria-label="Click to reply to the audit query"
+          >Click here to reply</a
+        >
+      </div>
+
+      <div class="footer">
+        This is an automated email sent from the Audit Management System. If you
+        have any questions, please contact the Audit Department.
+      </div>
+    </div>
+  </body>
+</html>

--- a/audit_management/templates/emails/sending_mail.html
+++ b/audit_management/templates/emails/sending_mail.html
@@ -1,5 +1,0 @@
-<!-- templates/emails/sending_mail.html -->
-<div>
-    <h3>Email Notification</h3>
-    <p>third attempt of sending mail from template</p>
-</div>


### PR DESCRIPTION
- Ensure users can respond even if status is set to "No Response" at any audit level.
- Implement auto-generated emails to notify users when TAT is exceeded.
- Allow responses even after TAT expiry as per requirement.