### PR TITLE
chore: Skip 'Gondia TW (Operation)' in migrate_audit_level_to_child.py

### DIFF
--- a/audit_management/patches/migrate_audit_level_to_child.py
+++ b/audit_management/patches/migrate_audit_level_to_child.py
@@ -2,10 +2,6 @@ import frappe
 
 def execute():
 
-    print("\n==============================")
-    print("🚀 Starting Audit Level Migration Patch")
-    print("==============================\n")
-
     STAGE_MAP = [
         ("stage_1_bm_emp_id", "stage_1_bm_mail", 1, "BM"),
         ("stage_2_dh_emp_id", "stage_2_dh_mail", 2, "DH"),
@@ -21,11 +17,13 @@ def execute():
     ]
 
     audit_levels = frappe.get_all("Audit Level", fields=["name"])
-    print(f"🔎 Total Audit Level Records Found: {len(audit_levels)}\n")
 
     for level in audit_levels:
+        
+        # 🔴 EXCLUDE THIS RECORD
+        if level.name == "Gondia TW (Operation)":
+            continue
 
-        print(f"➡ Processing Audit Level: {level.name}")
         doc = frappe.get_doc("Audit Level", level.name)
 
         doc.set("audit_stages", [])  # Reset child table completely
@@ -66,10 +64,4 @@ def execute():
         doc.flags.ignore_validate = True
         doc.save(ignore_permissions=True)
 
-        print("   ✅ Rebuilt & Sorted Correctly\n")
-
     frappe.db.commit()
-
-    print("======================================")
-    print("🎯 Audit Level Migration Patch Completed")
-    print("======================================\n")


### PR DESCRIPTION
This commit formalizes a manual change made to the
 patch. It adds a specific condition
to skip processing the 'Gondia TW (Operation)' Audit Level document during the execution of this particular patch.

This change was identified in the On branch chore/skip-gondia-tw-operation-in-audit-level-patch Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   audit_management/patches/migrate_audit_level_to_child.py output and is being
committed as per user request to capture all recent modifications.