### PR TITLE
Feat/added new field in audit level doctype

### DIFF
--- a/audit_management/audit_management/doctype/audit_level/audit_level.js
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.js
@@ -1,4 +1,24 @@
 frappe.ui.form.on('Audit Level', {
+    onload: function(frm) {
+        // Set query for branch to show sol_id and branch_name
+        frm.set_query("emp_branch", function() {
+            return {
+                query: "audit_management.audit_management.doctype.audit_level.audit_level.branch_query"
+            };
+        });
+
+        // Auto-populate division if new record
+        if (frm.is_new() && !frm.doc.division) {
+            frappe.call({
+                method: "audit_management.audit_management.doctype.audit_level.audit_level.get_user_division",
+                callback: function(r) {
+                    if (r.message) {
+                        frm.set_value("division", r.message);
+                    }
+                }
+            });
+        }
+    },
     refresh: function(frm) {
         // audit_stages should be always visible now
         frm.toggle_display("audit_stages", true);

--- a/audit_management/audit_management/doctype/audit_level/audit_level.json
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.json
@@ -9,6 +9,8 @@
  "engine": "InnoDB",
  "field_order": [
   "emp_branch",
+  "column_break_usmq",
+  "division",
   "stage_1_bm_section",
   "stage_1_bm_emp_id",
   "column_break_4v6eo",
@@ -420,8 +422,14 @@
    "fieldname": "emp_branch",
    "fieldtype": "Link",
    "label": "Branch",
-   "options": "Branch",
+   "options": "Sahayog Branch",
    "unique": 1
+  },
+  {
+   "fieldname": "division",
+   "fieldtype": "Data",
+   "label": "Division",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_v1upb",
@@ -737,12 +745,16 @@
   {
    "fieldname": "column_break_dmkb",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_usmq",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-08 12:42:13.544744",
- "modified_by": "9517@sahayog.com",
+ "modified": "2026-04-22 17:34:41.916520",
+ "modified_by": "Administrator",
  "module": "Audit Management",
  "name": "Audit Level",
  "naming_rule": "By fieldname",

--- a/audit_management/audit_management/doctype/audit_level/audit_level.py
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.py
@@ -6,6 +6,10 @@ from frappe.model.document import Document
 from audit_management.audit_management.utils import is_new_system_enabled
 
 class AuditLevel(Document):
+    def before_insert(self):
+        if not self.division:
+            self.division = get_user_division()
+
     def validate(self):
         if is_new_system_enabled():
             self.remove_blank_rows()
@@ -28,3 +32,35 @@ def fetch_employee(employee_id):
     
     # Return as a list to maintain compatibility with the JS callback expectations
     return [employee] if employee else []
+
+@frappe.whitelist()
+def get_user_division():
+    """Fetch division of the current logged-in user from Employee doctype safely."""
+    # Based on inspection, the field name is 'custom_division'
+    if not frappe.db.has_column("Employee", "custom_division"):
+        # If custom_division field is missing, try to get department as a fallback
+        return frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "department")
+    
+    employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "custom_division")
+    return employee
+
+@frappe.whitelist()
+def branch_query(doctype, txt, searchfield, start, page_len, filters):
+    """Query to display sol_id and branch in Link field."""
+    return frappe.db.sql(f"""
+        SELECT 
+            name, 
+            CONCAT(sol_id, '-', branch) as description
+        FROM 
+            `tabSahayog Branch`
+        WHERE 
+            (name LIKE %(txt)s OR sol_id LIKE %(txt)s OR branch LIKE %(txt)s)
+        ORDER BY 
+            name ASC
+        LIMIT 
+            %(start)s, %(page_len)s
+    """, {
+        "txt": f"%{txt}%",
+        "start": start,
+        "page_len": page_len
+    })


### PR DESCRIPTION
 - Updated emp_branch link to reference the Sahayog Branch doctype instead of the standard Branch.
  - Added a new division field to the Audit Level doctype to track employee divisions.
  - Implemented branch_query to display branch search results in the sol_id - branch format.
  - Added auto-population logic for the division field using the logged-in user's Employee record.
  - Implemented safety fallback in the controller to fetch department if the custom_division field is missing.
  - Added server-side hooks (before_insert) to ensure data integrity for the division field during creation.
