### PR TITLE
Manual Email Entry & Auto-Sync for Audit Levels

### DIFF
--- a/audit_management/audit_management/doctype/audit_items/audit_items.json
+++ b/audit_management/audit_management/doctype/audit_items/audit_items.json
@@ -64,7 +64,6 @@
   },
   {
    "columns": 2,
-   "fetch_from": "employee.company_email",
    "fieldname": "email",
    "fieldtype": "Data",
    "in_list_view": 1,

--- a/audit_management/audit_management/doctype/audit_level/audit_level.js
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.js
@@ -66,7 +66,11 @@ frappe.ui.form.on('Audit Items', {
                         let data = r.message[0];
                         frappe.model.set_value(cdt, cdn, "employee_name", data.employee_name);
                         frappe.model.set_value(cdt, cdn, "user_id", data.user_id);
-                        frappe.model.set_value(cdt, cdn, "email", data.company_email);
+                        
+                        // Only set email if it exists in Employee record
+                        if (data.company_email) {
+                            frappe.model.set_value(cdt, cdn, "email", data.company_email);
+                        }
                     }
                 }
             });

--- a/audit_management/audit_management/doctype/audit_level/audit_level.json
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.json
@@ -506,7 +506,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "stage_5_gm_emp_id.company_email",
    "fieldname": "stage_5_gm_mail",
    "fieldtype": "Data",
    "hidden": 1,
@@ -561,7 +560,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "stage_6_hr_emp_id.company_email",
    "fieldname": "stage_6_hr_mail",
    "fieldtype": "Data",
    "hidden": 1,
@@ -612,7 +610,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "stage_8_coo_emp_id.company_email",
    "fieldname": "stage_8_coo_mail",
    "fieldtype": "Data",
    "hidden": 1,
@@ -658,7 +655,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "stage_7_chro_emp_id.company_email",
    "fieldname": "stage_7_chro_mail",
    "fieldtype": "Data",
    "hidden": 1,
@@ -693,7 +689,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "stage_10_ceo_emp_id.company_email",
    "fieldname": "stage_10_ceo_mail",
    "fieldtype": "Data",
    "hidden": 1,
@@ -727,7 +722,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "stage_9_cfo_emp_id.company_email",
    "fieldname": "stage_9_cfo_mail",
    "fieldtype": "Data",
    "hidden": 1,

--- a/audit_management/audit_management/doctype/audit_level/audit_level.py
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.py
@@ -13,6 +13,9 @@ class AuditLevel(Document):
     def validate(self):
         if is_new_system_enabled():
             self.remove_blank_rows()
+            self.update_employee_emails()
+        else:
+            self.sync_new_to_old_stages()
 
     def remove_blank_rows(self):
         cleaned_rows = []
@@ -21,6 +24,54 @@ class AuditLevel(Document):
                 if row.stage and row.stage_name and row.employee:
                     cleaned_rows.append(row)
             self.audit_stages = cleaned_rows
+
+    def update_employee_emails(self):
+        """If email is manually entered in Audit Stages, update it in Employee doctype."""
+        if not hasattr(self, "audit_stages"):
+            return
+
+        for row in self.audit_stages:
+            if row.employee and row.email:
+                # Check if employee already has this email
+                current_email = frappe.db.get_value("Employee", row.employee, "company_email")
+                if not current_email and row.email:
+                    # Update Employee doctype
+                    frappe.db.set_value("Employee", row.employee, "company_email", row.email)
+                    frappe.msgprint(frappe._("Updated email for Employee {0}").format(row.employee))
+
+    def sync_new_to_old_stages(self):
+        """Syncs child table data to old hardcoded stage fields for backward compatibility."""
+        if not hasattr(self, "audit_stages"):
+            return
+        
+        # Mapping prefix to stage number
+        mapping = {
+            "1": "stage_1_bm", "2": ["stage_2_dh", "stage_2_com"], "3": ["stage_3_rm", "stage_3_rom"],
+            "4": ["stage_4_zm", "stage_4_zom"], "5": "stage_5_gm", "6": "stage_6_hr",
+            "7": "stage_7_chro", "8": "stage_8_coo", "9": "stage_9_cfo", "10": "stage_10_ceo"
+        }
+
+        for row in self.audit_stages:
+            stage_num = str(row.stage)
+            prefix_data = mapping.get(stage_num)
+            if not prefix_data: continue
+
+            prefixes = [prefix_data] if isinstance(prefix_data, str) else prefix_data
+            
+            # Find which prefix matches this stage name (e.g., DH vs COM)
+            for p in prefixes:
+                # If name matches or it's a single prefix stage
+                if len(prefixes) == 1 or p.split("_")[-1].upper() in row.stage_name.upper():
+                    self.set(f"{p}_emp_id", row.employee)
+                    self.set(f"{p}_name", row.employee_name)
+                    self.set(f"{p}_user_id", row.user_id)
+                    self.set(f"{p}_mail", row.email)
+                    
+                    # Also update employee email if manually typed in old system
+                    if row.employee and row.email:
+                        current_email = frappe.db.get_value("Employee", row.employee, "company_email")
+                        if not current_email:
+                            frappe.db.set_value("Employee", row.employee, "company_email", row.email)
 
 @frappe.whitelist()
 def fetch_employee(employee_id):


### PR DESCRIPTION
* Manual Email Overrides: Removed fetch_from constraints to allow users to manually enter emails when not available in the Employee record.
   * Employee Master Sync: Implemented backend logic to automatically update the Employee record's company email if a manual entry is provided
     during save.
   * Data Persistence: Updated frontend triggers to prevent system auto-fetches from overwriting manually entered email addresses.
   * Legacy & New System Compatibility: Ensured email synchronization works seamlessly across both the child-table based system and legacy
     hardcoded stages.
   * Validation Integrity: Maintained structural integrity by ensuring blank rows are removed and data is correctly mapped between different
     UI views.
   * Non-Destructive Updates: System only updates the Employee master if the email field was previously empty, preserving existing verified
     data.