### PR TITLE
Feat/added same permission logic in audit level doctype

### DIFF
--- a/audit_management/audit_management/doctype/audit_level/audit_level.py
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
-from audit_management.audit_management.utils import is_new_system_enabled
+from audit_management.audit_management.utils import is_new_system_enabled, get_user_allowed_divisions
 
 
 class AuditLevel(Document):
@@ -154,51 +154,18 @@ def branch_query(doctype, txt, searchfield, start, page_len, filters):
 # PERMISSION LOGIC (FINAL)
 # -------------------------
 
-def apply_cross_division_access(divisions):
-    """Handle cross-access between specific divisions."""
-    cross_access = ["Multistate", "Retail Banking", "Retail Branch Banking"]
-
-    if any(d in divisions for d in cross_access):
-        return list(set(divisions + cross_access))
-
-    return list(set(divisions))
-
-
-def get_user_allowed_divisions(user):
-    user_div = frappe.db.get_value(
-        "Employee", {"user_id": user}, "custom_division"
-    )
-
-    if not user_div:
-        return []
-
-    settings = frappe.get_single("Audit Management Settings")
-
-    if not hasattr(settings, "division_permissions") or not settings.division_permissions:
-        return [user_div]
-
-    allowed = [
-        row.allowed_division
-        for row in settings.division_permissions
-        if row.source_division == user_div
-    ]
-
-    if user_div not in allowed:
-        allowed.append(user_div)
-
-    return allowed
-
-
 def get_permission_query_conditions(user=None):
     if not user:
         user = frappe.session.user
 
-    if user == "Administrator" or "System Manager" in frappe.get_roles(user):
+    roles = frappe.get_roles(user)
+
+    # System Admins see everything
+    if "Administrator" in roles or "System Manager" in roles:
         return ""
 
+    # Division check
     allowed_divisions = get_user_allowed_divisions(user)
-    allowed_divisions = apply_cross_division_access(allowed_divisions)
-
     if not allowed_divisions:
         return "1=0"
 
@@ -214,12 +181,11 @@ def has_permission(doc, ptype, user=None):
     roles = frappe.get_roles(user)
 
     # 1. System Admins see everything
-    if user == "Administrator" or "System Manager" in roles:
+    if "Administrator" in roles or "System Manager" in roles:
         return True
 
-    # 2. Get allowed divisions (handles Multistate/Retail cross-access)
+    # 2. Get allowed divisions
     allowed_divisions = get_user_allowed_divisions(user)
-    allowed_divisions = apply_cross_division_access(allowed_divisions)
     if not allowed_divisions:
         return False
 

--- a/audit_management/audit_management/doctype/my_audits/my_audits.py
+++ b/audit_management/audit_management/doctype/my_audits/my_audits.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import now, time_diff_in_seconds, time_diff_in_hours, getdate, nowdate
-from audit_management.audit_management.utils import get_working_days, update_audit_aging
+from audit_management.audit_management.utils import get_working_days, update_audit_aging, get_user_allowed_divisions
 
 
 class MyAudits(Document):
@@ -635,23 +635,6 @@ def send_daily_reminders():
                     reference_doctype=doc.doctype,
                     reference_name=doc.name
                 )
-
-
-def get_user_allowed_divisions(user):
-    user_div = frappe.db.get_value(
-        "Employee", {"user_id": user}, "custom_division")
-    if not user_div:
-        return []
-
-    settings = frappe.get_single("Audit Management Settings")
-    if not hasattr(settings, "division_permissions") or not settings.division_permissions:
-        return [user_div]
-
-    allowed = [
-        row.allowed_division for row in settings.division_permissions if row.source_division == user_div]
-    if user_div not in allowed:
-        allowed.append(user_div)
-    return allowed
 
 
 # def get_permission_query_conditions(user=None):

--- a/audit_management/audit_management/utils.py
+++ b/audit_management/audit_management/utils.py
@@ -29,3 +29,28 @@ def update_audit_aging(doc):
     end_date = getdate(doc.modified) if doc.status == "Close" else getdate(nowdate())
     
     doc.aging = get_working_days(start_date, end_date)
+
+def get_user_allowed_divisions(user):
+    """Fetch allowed divisions for a user based on Audit Management Settings."""
+    user_div = frappe.db.get_value(
+        "Employee", {"user_id": user}, "custom_division"
+    )
+
+    if not user_div:
+        return []
+
+    settings = frappe.get_single("Audit Management Settings")
+
+    if not hasattr(settings, "division_permissions") or not settings.division_permissions:
+        return [user_div]
+
+    allowed = [
+        row.allowed_division
+        for row in settings.division_permissions
+        if row.source_division == user_div
+    ]
+
+    if user_div not in allowed:
+        allowed.append(user_div)
+
+    return allowed


### PR DESCRIPTION
 Centralized Permission Logic: Moved the get_user_allowed_divisions function to utils.py to create a single source of truth for
     division-based access across the application.
   - Fixed Audit Level Permissions: Removed hardcoded division names from Audit Level and aligned it with the settings-driven approach used in
     My Audits.
   - Cross-Division Visibility: Resolved the issue where Multistate and Retail divisions could not see each other's records by ensuring both
     DocTypes utilize the Division Permissions configuration table.
   - Maintained Functional Integrity: Ensured that My Audits specific rules—such as bypass permissions for pending responders and
     owners—remain intact while using the shared logic.
   - Code Refactoring: Eliminated redundant code from audit_level.py and my_audits.py to improve long-term maintainability and consistency.

