### PR TITLE
Feat/refined my audits visibility control for audit members

### DIFF
--- a/audit_management/audit_management/doctype/my_audits/my_audits.py
+++ b/audit_management/audit_management/doctype/my_audits/my_audits.py
@@ -770,16 +770,10 @@ def get_permission_query_conditions(user=None):
     )
     """
     if is_audit_manager:
-        return f"`tabMy Audits`.emp_division IN ({divisions_sql})"
+     return f"`tabMy Audits`.emp_division IN ({divisions_sql})"
 
-    if is_audit_team:
-        return f"""
-            (
-                (`tabMy Audits`.status != 'Draft' AND `tabMy Audits`.emp_division IN ({divisions_sql}))
-                OR 
-                (`tabMy Audits`.owner = '{user}')
-            )
-        """
+    if "Audit Member" in roles and not is_audit_manager:
+      return f"`tabMy Audits`.owner = '{user}'"
 
     # ✅ FINAL CONTROL
     return f"""

--- a/audit_management/audit_management/utils.py
+++ b/audit_management/audit_management/utils.py
@@ -30,27 +30,41 @@ def update_audit_aging(doc):
     
     doc.aging = get_working_days(start_date, end_date)
 
-def get_user_allowed_divisions(user):
-    """Fetch allowed divisions for a user based on Audit Management Settings."""
+def get_user_allowed_divisions(user=None):
+    """
+    Fetch all divisions user can access.
+
+    Includes:
+    - User's own division
+    - Cross division mappings from settings
+    """
+
+    if not user:
+        user = frappe.session.user
+
+    # Get employee division
     user_div = frappe.db.get_value(
-        "Employee", {"user_id": user}, "custom_division"
+        "Employee",
+        {"user_id": user},
+        "custom_division"
     )
 
     if not user_div:
         return []
 
+    allowed_divisions = {user_div}
+
     settings = frappe.get_single("Audit Management Settings")
 
-    if not hasattr(settings, "division_permissions") or not settings.division_permissions:
-        return [user_div]
+    if not getattr(settings, "division_permissions", None):
+        return list(allowed_divisions)
 
-    allowed = [
-        row.allowed_division
-        for row in settings.division_permissions
-        if row.source_division == user_div
-    ]
+    # Add mapped divisions
+    for row in settings.division_permissions:
+        if (
+            row.source_division == user_div
+            and row.allowed_division
+        ):
+            allowed_divisions.add(row.allowed_division)
 
-    if user_div not in allowed:
-        allowed.append(user_div)
-
-    return allowed
+    return list(allowed_divisions)


### PR DESCRIPTION
- Updated My Audits permission logic so Audit Members can view only their own created audit queries.
- Restricted Audit Members from viewing other users’ records, even within the same division.
- Retained existing Draft and Non-Draft visibility for self-created records.
- Kept Audit Manager access unchanged for division-based and cross-division visibility control.
- Preserved existing stage-based access flow for pending/responded users without impacting current functionality.