### PR TITLE
Feat/refactor audit level naming logic to use sahayog branch field

### DIFF
--- a/audit_management/audit_management/doctype/audit_level/audit_level.json
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.json
@@ -9,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "emp_branch",
+  "sahayog_branch",
   "column_break_usmq",
   "division",
   "stage_1_bm_section",
@@ -421,14 +422,15 @@
   {
    "fieldname": "emp_branch",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Branch",
-   "options": "Sahayog Branch"
+   "options": "Branch"
   },
   {
    "fieldname": "division",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "label": "Division",
-   "read_only": 1
+   "options": "Division"
   },
   {
    "fieldname": "column_break_v1upb",
@@ -742,11 +744,17 @@
   {
    "fieldname": "column_break_usmq",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "sahayog_branch",
+   "fieldtype": "Link",
+   "label": "Sahayog Branch",
+   "options": "Sahayog Branch"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-28 16:19:14.545283",
+ "modified": "2026-05-12 10:48:32.608825",
  "modified_by": "Administrator",
  "module": "Audit Management",
  "name": "Audit Level",

--- a/audit_management/audit_management/doctype/audit_level/audit_level.py
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.py
@@ -82,32 +82,29 @@ class AuditLevel(Document):
                                 "Employee", row.employee, "company_email", row.email)
 
     def autoname(self):
-        # Fetch SOL ID from linked branch
-        sol_id = frappe.db.get_value(
-            "Sahayog Branch",
-            self.emp_branch,
-            "sol_id"
-        ) or "NA"
+        if not self.division:
+            self.division = get_user_division()
+
+        sol_id = self.sahayog_branch
+
+        if not sol_id:
+            frappe.throw("Sahayog Branch is mandatory before naming.")
 
         division = (self.division or "").strip()
 
-        # Generate smart division abbreviation
         words = division.split()
 
         if len(words) == 1:
-            # Single word → first 3 chars
             division_abbr = words[0][:3].upper()
 
         elif words[0].isupper() and len(words[0]) <= 5:
-            # Existing acronym like JLL, HR, IT
             division_abbr = words[0].upper()
 
         else:
-            # Multi-word → initials
             division_abbr = "".join(word[0] for word in words).upper()
 
         self.name = f"{sol_id}-{division_abbr}"
-
+            
 @frappe.whitelist()
 def fetch_employee(employee_id):
     """Fetch employee data safely using Frappe API instead of raw SQL."""


### PR DESCRIPTION
- Removed obsolete set_missing_values() dependency from autoname() to fix save-time AttributeError.
- Updated Audit Level naming logic to use sahayog_branch instead of legacy emp_branch.
- Added validation to ensure sahayog_branch is mandatory before document naming.
- Retained dynamic division-based abbreviation generation for consistent naming format.
- Aligned naming flow with new branch architecture and migration-ready structure.