### PR TITLE
Feat/added patch in audit to store stage fields in child table

### DIFF
--- a/audit_management/audit_management/doctype/audit_level/audit_level.json
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "allow_rename": 1,
  "autoname": "format:{division}-{emp_branch}",
  "creation": "2024-09-02 11:17:28.344188",
@@ -422,9 +423,8 @@
   {
    "fieldname": "emp_branch",
    "fieldtype": "Link",
-   "hidden": 1,
    "label": "Branch",
-   "options": "Branch"
+   "options": "Sahayog Branch"
   },
   {
    "fieldname": "division",
@@ -749,12 +749,13 @@
    "fieldname": "sahayog_branch",
    "fieldtype": "Link",
    "label": "Sahayog Branch",
-   "options": "Sahayog Branch"
+   "options": "Sahayog Branch",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-05-12 10:48:32.608825",
+ "modified": "2026-05-18 12:52:15.685862",
  "modified_by": "Administrator",
  "module": "Audit Management",
  "name": "Audit Level",

--- a/audit_management/audit_management/doctype/audit_level/audit_level.py
+++ b/audit_management/audit_management/doctype/audit_level/audit_level.py
@@ -82,29 +82,39 @@ class AuditLevel(Document):
                                 "Employee", row.employee, "company_email", row.email)
 
     def autoname(self):
-        if not self.division:
-            self.division = get_user_division()
+        # Fetch SOL ID from linked Sahayog Branch
+        if not self.sahayog_branch:
+            # Fallback to legacy field if sahayog_branch is not yet selected during migration
+            branch_to_use = self.sahayog_branch or self.emp_branch
+            if not branch_to_use:
+                frappe.throw("Sahayog Branch is mandatory for naming.")
+        else:
+            branch_to_use = self.sahayog_branch
 
-        sol_id = self.sahayog_branch
-
-        if not sol_id:
-            frappe.throw("Sahayog Branch is mandatory before naming.")
+        sol_id = frappe.db.get_value(
+            "Sahayog Branch",
+            branch_to_use,
+            "sol_id"
+        ) or "NA"
 
         division = (self.division or "").strip()
 
+        # Generate smart division abbreviation
         words = division.split()
 
         if len(words) == 1:
+            # Single word → first 3 chars
             division_abbr = words[0][:3].upper()
 
         elif words[0].isupper() and len(words[0]) <= 5:
+            # Existing acronym like JLL, HR, IT
             division_abbr = words[0].upper()
 
         else:
+            # Multi-word → initials
             division_abbr = "".join(word[0] for word in words).upper()
 
-        self.name = f"{sol_id}-{division_abbr}"
-            
+        self.name = f"{sol_id}-{division_abbr}"            
 @frappe.whitelist()
 def fetch_employee(employee_id):
     """Fetch employee data safely using Frappe API instead of raw SQL."""

--- a/audit_management/patches.txt
+++ b/audit_management/patches.txt
@@ -9,4 +9,5 @@ audit_management.patches.fixtures.audit_permission_patch
 audit_management.patches.migrate_audit_level_to_child
 audit_management.patches.migrate_audit_level_to_my_audits_child
 audit_management.patches.migrate_production_data_v3
+audit_management.patches.migrate_production_data_v4
 audit_management.patches.migrate_hardcoded_to_child_table

--- a/audit_management/patches/migrate_production_data_v3.py
+++ b/audit_management/patches/migrate_production_data_v3.py
@@ -1,94 +1,169 @@
 import frappe
 
-def ensure_branch_exists(branch_name):
-    if branch_name and not frappe.db.exists("Branch", branch_name):
-        frappe.get_doc({"doctype": "Branch", "branch": branch_name}).insert(ignore_permissions=True)
+
+def get_division_from_user(user):
+    """Helper to fetch division from Employee record linked to user."""
+    if not user:
+        return None
+    
+    # Check Employee linked to user_id
+    emp = frappe.db.get_value(
+        "Employee", 
+        {"user_id": user}, 
+        ["custom_division", "department"], 
+        as_dict=True
+    )
+    
+    if emp:
+        return emp.custom_division or emp.department
+    return None
+
 
 def execute():
-    # 1. Ensure Audit Stages exist
-    stages = ["BM", "DH", "COM", "RM", "ROM", "ZM", "ZOM", "GM", "HR", "COO", "CEO"]
+    """
+    PRODUCTION-GRADE MIGRATION PATCH (V3)
+    Focus: Audit Level Setup with robust SOL-based branch mapping and division set.
+    """
+    print("\n================ PATCH V3 STARTED (Audit Level) ================\n")
+
+    summary = {
+        "total": 0,
+        "success": 0,
+        "failed": 0,
+        "division_updated": 0,
+        "branch_updated": 0,
+        "stages_populated": 0
+    }
+
+    stages = [
+        "BM", "DH", "COM", "RM", "ROM",
+        "ZM", "ZOM", "GM", "HR", "CHRO", "COO", "CFO", "CEO"
+    ]
+
     for s in stages:
         if not frappe.db.exists("Audit Stage", s):
             try:
                 frappe.get_doc({"doctype": "Audit Stage", "name": s, "stage_name": s}).insert(ignore_permissions=True)
-            except Exception: pass
+                print(f"Created Audit Stage: {s}")
+            except Exception:
+                frappe.log_error(title=f"Audit Stage Creation Failed - {s}")
 
-    # 2. Migrate Audit Level
-    for al in frappe.get_all("Audit Level", pluck="name"):
-        try:
-            doc = frappe.get_doc("Audit Level", al)
-            if doc.get("audit_stages"): continue
-            
-            mapping = [
-                {"stage": 1, "name": "BM",  "user": doc.stage_1_bm_user_id,  "emp": doc.stage_1_bm_emp_id, "n": doc.stage_1_bm_name},
-                {"stage": 2, "name": "DH",  "user": doc.stage_2_dh_user_id,  "emp": doc.stage_2_dh_emp_id, "n": doc.stage_2_dh_name},
-                {"stage": 2, "name": "COM", "user": doc.stage_2_com_user_id, "emp": doc.stage_2_com_emp_id, "n": doc.stage_2_com_name},
-                {"stage": 3, "name": "RM",  "user": doc.stage_3_rm_user_id,  "emp": doc.stage_3_rm_emp_id, "n": doc.stage_3_rm_name},
-                {"stage": 3, "name": "ROM", "user": doc.stage_3_rom_user_id, "emp": doc.stage_3_rom_emp_id, "n": doc.stage_3_rom_name},
-                {"stage": 4, "name": "ZM",  "user": doc.stage_4_zm_user_id,  "emp": doc.stage_4_zm_emp_id, "n": doc.stage_4_zm_name},
-                {"stage": 4, "name": "ZOM", "user": doc.stage_4_zom_user_id, "emp": doc.stage_4_zom_emp_id, "n": doc.stage_4_zom_name},
-                {"stage": 5, "name": "GM",  "user": doc.stage_5_gm_user_id,  "emp": doc.stage_5_gm_emp_id, "n": doc.stage_5_gm_name},
-                {"stage": 6, "name": "HR",  "user": doc.stage_6_hr_user_id,  "emp": doc.stage_6_hr_emp_id, "n": doc.stage_6_hr_name},
-                {"stage": 8, "name": "COO", "user": doc.stage_8_coo_user_id, "emp": doc.stage_8_coo_emp_id, "n": doc.stage_8_coo_name},
-                {"stage": 10,"name": "CEO", "user": doc.stage_10_ceo_user_id,"emp": doc.stage_10_ceo_emp_id, "n": doc.stage_10_ceo_name},
-            ]
-            for s in mapping:
-                if s.get("emp"):
-                    doc.append("audit_stages", {"stage": s["stage"], "stage_name": s["name"], "employee": s["emp"], "user_id": s["user"], "employee_name": s["n"], "status": "Pending"})
-            doc.flags.ignore_links = True
-            doc.flags.ignore_mandatory = True
-            doc.save(ignore_permissions=True)
-            frappe.db.commit()
-        except Exception:
-            frappe.db.rollback()
-            frappe.log_error(frappe.get_traceback(), f"Audit Level Migration Failed: {al}")
-
-    # 3. Migrate My Audits (using the logic that worked for you)
-    ma_mapping = [
-        {"prefix": "bm", "stage": 1, "label": "BM"},
-        {"prefix": "dh", "stage": 2, "label": "DH"},
-        {"prefix": "com", "stage": 2, "label": "COM"},
-        {"prefix": "rm", "stage": 3, "label": "RM"},
-        {"prefix": "rom", "stage": 3, "label": "ROM"},
-        {"prefix": "zm", "stage": 4, "label": "ZM"},
-        {"prefix": "zom", "stage": 4, "label": "ZOM"},
-        {"prefix": "gm", "stage": 5, "label": "GM"},
-        {"prefix": "hr", "stage": 6, "label": "HR"},
-        {"prefix": "coo", "stage": 7, "label": "COO"},
-        {"prefix": "ceo", "stage": 8, "label": "CEO"}
+    al_mapping = [
+        {"stage": 1, "name": "BM", "prefix": "stage_1_bm"},
+        {"stage": 2, "name": "DH", "prefix": "stage_2_dh"},
+        {"stage": 2, "name": "COM", "prefix": "stage_2_com"},
+        {"stage": 3, "name": "RM", "prefix": "stage_3_rm"},
+        {"stage": 3, "name": "ROM", "prefix": "stage_3_rom"},
+        {"stage": 4, "name": "ZM", "prefix": "stage_4_zm"},
+        {"stage": 4, "name": "ZOM", "prefix": "stage_4_zom"},
+        {"stage": 5, "name": "GM", "prefix": "stage_5_gm"},
+        {"stage": 6, "name": "HR", "prefix": "stage_6_hr"},
+        {"stage": 7, "name": "CHRO", "prefix": "stage_7_chro"},
+        {"stage": 8, "name": "COO", "prefix": "stage_8_coo"},
+        {"stage": 9, "name": "CFO", "prefix": "stage_9_cfo"},
+        {"stage": 10, "name": "CEO", "prefix": "stage_10_ceo"},
     ]
-    for ma in frappe.get_all("My Audits", pluck="name"):
+
+    all_al = frappe.get_all("Audit Level", pluck="name")
+    summary["total"] = len(all_al)
+
+    processed = 0
+    for al_name in all_al:
+        processed += 1
         try:
-            doc = frappe.get_doc("My Audits", ma)
-            if doc.get("audit_stages"): continue
-            ensure_branch_exists(doc.emp_branch)
-            
-            has_data = False
-            for m in ma_mapping:
-                uid = doc.get(f"{m['prefix']}_user_id")
-                eml = doc.get(f"{m['prefix']}_mail")
-                emp = None
-                if uid: emp = frappe.db.get_value("Employee", {"user_id": uid}, "name")
-                if not emp and eml: emp = frappe.db.get_value("Employee", {"company_email": eml}, "name")
+            print(f"Processing Audit Level: {al_name}")
+            doc = frappe.get_doc("Audit Level", al_name)
+            updated = False
+
+            # A. Set Division from Owner
+            if not doc.division:
+                div = get_division_from_user(doc.owner)
+                if div:
+                    doc.division = div
+                    summary["division_updated"] += 1
+                    updated = True
+                    print(f"  [SET] Division: {div}")
+
+            # B. Set Sahayog Branch (SOL Match -> Name Match)
+            if not doc.sahayog_branch and doc.emp_branch:
+                # Normalization
+                branch_name = (doc.emp_branch or "").strip()
                 
-                if emp:
+                # 1. Get SOL ID from old Branch Doctype
+                sol_id = frappe.db.get_value("Branch", branch_name, "sol_id")
+                
+                # 2. Match using SOL ID
+                if sol_id:
+                    sb = frappe.db.get_value("Sahayog Branch", {"sol_id": sol_id}, "name")
+                    if sb:
+                        doc.sahayog_branch = sb
+                        updated = True
+                        summary["branch_updated"] += 1
+                        print(f"  [SOL MATCH] {branch_name} -> {sb}")
+
+                # 3. Name fallback
+                if not doc.sahayog_branch:
+                    sb = frappe.db.get_value("Sahayog Branch", {"branch": branch_name}, "name")
+                    if not sb and frappe.db.exists("Sahayog Branch", branch_name):
+                        sb = branch_name # Direct match
+                        
+                    if sb:
+                        doc.sahayog_branch = sb
+                        updated = True
+                        summary["branch_updated"] += 1
+                        print(f"  [NAME MATCH] {branch_name} -> {sb}")
+                
+                # Log failure
+                if not doc.sahayog_branch:
+                    print(f"  [MISSING] Sahayog Branch not found for {branch_name}")
+                    frappe.log_error(
+                        title="Missing Sahayog Branch Mapping",
+                        message=f"Audit Level: {doc.name}\nBranch: {branch_name}\nSOL ID: {sol_id}"
+                    )
+
+            # C. Populate Audit Stages
+            existing_stages = [d.stage_name for d in doc.audit_stages]
+            stages_added = 0
+            for m in al_mapping:
+                if m["name"] in existing_stages: continue
+                
+                p = m["prefix"]
+                emp_id = doc.get(f"{p}_emp_id") or (doc.get("stage_9_cfo_emp_id") if m["name"] == "CFO" else None)
+                
+                if emp_id:
                     doc.append("audit_stages", {
-                        "stage": m["stage"], "stage_name": m["label"],
-                        "employee": emp, "user_id": uid,
-                        "employee_name": doc.get(f"{m['prefix']}_name"),
-                        "email": eml,
-                        "status": doc.get(f"{m['prefix']}_user_status") or "Pending",
-                        "response": doc.get(f"{m['prefix']}_response_box"),
-                        "attachment": doc.get(f"{m['prefix']}_attach_box"),
-                        "pending_time": doc.get(f"{m['prefix']}_pending_time")
+                        "stage": m["stage"],
+                        "stage_name": m["name"],
+                        "employee": emp_id,
+                        "user_id": doc.get(f"{p}_user_id") or (doc.get("stage_9_user_id") if m["name"] == "CFO" else None),
+                        "employee_name": doc.get(f"{p}_name") or (doc.get("stage_9_cfo_name") if m["name"] == "CFO" else None),
+                        "email": doc.get(f"{p}_mail") or (doc.get("stage_9_cfo_mail") if m["name"] == "CFO" else None),
                     })
-                    has_data = True
-            
-            if has_data:
-                doc.flags.ignore_links = True
+                    stages_added += 1
+                    updated = True
+
+            if stages_added > 0:
+                summary["stages_populated"] += 1
+
+            if updated:
+                doc.flags.ignore_validate = True
                 doc.flags.ignore_mandatory = True
+                doc.flags.ignore_links = True
+                doc.flags.ignore_version = True  # Added ignore_version
                 doc.save(ignore_permissions=True)
-                frappe.db.commit()
-        except Exception:
+                
+                if processed % 50 == 0:
+                    frappe.db.commit()
+            
+            summary["success"] += 1
+
+        except Exception as e:
             frappe.db.rollback()
-            frappe.log_error(frappe.get_traceback(), f"My Audits Migration Failed: {ma}")
+            summary["failed"] += 1
+            print(f"  [FAILED] {al_name}: {str(e)}")
+            frappe.log_error(title=f"Audit Level Migration Failed - {al_name}")
+
+    frappe.db.commit() # Final commit
+    print("\n================ MIGRATION SUMMARY (V3) ================")
+    for key, val in summary.items(): print(f"{key.replace('_', ' ').title()}: {val}")
+    print("========================================================\n")

--- a/audit_management/patches/migrate_production_data_v4.py
+++ b/audit_management/patches/migrate_production_data_v4.py
@@ -1,0 +1,195 @@
+import frappe
+
+def get_employee_from_mapping(uid=None, email=None, employee_name=None):
+    emp = None
+
+    # Priority 1 → user_id
+    if uid:
+        emp = frappe.db.get_value(
+            "Employee",
+            {"user_id": uid.strip()},
+            "name"
+        )
+
+    # Priority 2 → company_email
+    if not emp and email:
+        emp = frappe.db.get_value(
+            "Employee",
+            {"company_email": email.strip().lower()},
+            "name"
+        )
+
+    # Priority 3 → employee_name
+    if not emp and employee_name:
+        emp = frappe.db.get_value(
+            "Employee",
+            {"employee_name": employee_name.strip()},
+            "name"
+        )
+
+    return emp
+
+def get_division_from_user(user):
+    """Helper to fetch division from Employee record linked to user."""
+    if not user:
+        return None
+    
+    emp = frappe.db.get_value(
+        "Employee", 
+        {"user_id": user}, 
+        ["custom_division", "department"], 
+        as_dict=True
+    )
+    
+    if emp:
+        return emp.custom_division or emp.department
+    return None
+
+def execute():
+    """
+    PRODUCTION-GRADE MIGRATION PATCH (V4)
+    Focus: My Audits records migration with robust error handling and summaries.
+    """
+    print("\n================ PATCH V4 STARTED (My Audits) ================\n")
+
+    summary = {
+        "total": 0,
+        "success": 0,
+        "failed": 0,
+        "division_updated": 0,
+        "stages_populated": 0
+    }
+
+    ma_mapping = [
+        {"prefix": "bm", "stage": 1, "label": "BM"},
+        {"prefix": "dh", "stage": 2, "label": "DH"},
+        {"prefix": "com", "stage": 2, "label": "COM"},
+        {"prefix": "rm", "stage": 3, "label": "RM"},
+        {"prefix": "rom", "stage": 3, "label": "ROM"},
+        {"prefix": "zm", "stage": 4, "label": "ZM"},
+        {"prefix": "zom", "stage": 4, "label": "ZOM"},
+        {"prefix": "gm", "stage": 5, "label": "GM"},
+        {"prefix": "hr", "stage": 6, "label": "HR"},
+        {"prefix": "chro", "stage": 7, "label": "CHRO"},
+        {"prefix": "coo", "stage": 8, "label": "COO"},
+        {"prefix": "cfo", "stage": 9, "label": "CFO"},
+        {"prefix": "ceo", "stage": 10, "label": "CEO"}
+    ]
+
+    all_records = frappe.get_all("My Audits", pluck="name")
+    summary["total"] = len(all_records)
+    processed = 0
+
+    for ma_name in all_records:
+        processed += 1
+        try:
+            doc = frappe.get_doc("My Audits", ma_name)
+            
+            if doc.docstatus == 2:
+                summary["success"] += 1
+                continue
+
+            print(f"Processing My Audit: {ma_name}")
+            updated = False
+
+            # 1. Set emp_division from Owner if missing
+            if not doc.emp_division:
+                div = get_division_from_user(doc.owner)
+                if div:
+                    doc.emp_division = div
+                    updated = True
+                    summary["division_updated"] += 1
+                    print(f"  [SET] Division: {div}")
+
+            # 2. Populate audit_stages child table (Stage-wise check)
+            existing_stages = [d.stage_name for d in doc.audit_stages]
+            stages_added = 0
+
+            # Pre-fetch Audit Level stages for fallback
+            al_doc = None
+            if doc.emp_branch:
+                branch_name = (doc.emp_branch or "").strip()
+                
+                # First try direct name lookup
+                if frappe.db.exists("Audit Level", branch_name):
+                    al_doc = frappe.get_doc("Audit Level", branch_name)
+                else:
+                    # Try finding by Sahayog Branch mapping (populated in V3)
+                    al_name = frappe.db.get_value("Audit Level", {"sahayog_branch": branch_name}, "name")
+                    if al_name:
+                        al_doc = frappe.get_doc("Audit Level", al_name)
+            
+            if not al_doc and doc.emp_branch:
+                print(f"  [WARNING] Audit Level not found for branch: {doc.emp_branch}")
+                frappe.log_error(
+                    title="Audit Level Lookup Failed during My Audits Migration",
+                    message=f"My Audit: {doc.name}\nBranch: {doc.emp_branch}"
+                )
+
+            al_stages = {}
+            if al_doc:
+                for s in al_doc.audit_stages:
+                    al_stages[s.stage_name] = s
+
+            for m in ma_mapping:
+                if m["label"] in existing_stages:
+                    continue
+
+                prefix = m['prefix']
+                uid = doc.get(f"{prefix}_user_id")
+                email = doc.get(f"{prefix}_mail")
+                emp_name = doc.get(f"{prefix}_name")
+                
+                # Robust employee resolution
+                emp = get_employee_from_mapping(uid, email, emp_name)
+                
+                # Fallback to Audit Level if no specific user in transaction
+                if not emp:
+                    al_row = al_stages.get(m['label'])
+                    if al_row:
+                        emp = al_row.employee
+                        uid = al_row.user_id
+                        emp_name = al_row.employee_name
+                        email = al_row.email
+                
+                if emp:
+                    doc.append("audit_stages", {
+                        "stage": m["stage"],
+                        "stage_name": m["label"],
+                        "user_id": uid,
+                        "employee": emp,
+                        "employee_name": emp_name,
+                        "email": email,
+                        "status": doc.get(f"{prefix}_user_status") or "Pending",
+                        "response": doc.get(f"{prefix}_response_box"),
+                        "attachment": doc.get(f"{prefix}_attach_box"),
+                        "pending_time": doc.get(f"{prefix}_pending_time")
+                    })
+                    stages_added += 1
+                    updated = True
+            
+            if stages_added > 0:
+                summary["stages_populated"] += 1
+
+            if updated:
+                doc.flags.ignore_validate = True
+                doc.flags.ignore_mandatory = True
+                doc.flags.ignore_links = True
+                doc.flags.ignore_version = True  # Added ignore_version
+                doc.save(ignore_permissions=True)
+                
+                if processed % 50 == 0:
+                    frappe.db.commit()
+
+            summary["success"] += 1
+
+        except Exception as e:
+            frappe.db.rollback()
+            summary["failed"] += 1
+            print(f"  [FAILED] {ma_name}: {str(e)}")
+            frappe.log_error(title=f"My Audits Migration Failed - {ma_name}")
+
+    frappe.db.commit()
+    print("\n================ MIGRATION SUMMARY (V4) ================")
+    for key, val in summary.items(): print(f"{key.replace('_', ' ').title()}: {val}")
+    print("========================================================\n")


### PR DESCRIPTION
   - Refactored Audit Level migration (V3) to include automated division mapping from record owners.
   - Implemented robust Sahayog Branch mapping using SOL ID and name fallback logic in patches.
   - Created new My Audits migration patch (V4) for sequential transaction data transition.
   - Enhanced migration patches with batch committing, duplicate row prevention, and detailed logging.
   - Standardized Audit Level naming convention to use SOL ID from the Sahayog Branch field.
   - Updated Audit Level UI to make Sahayog Branch a mandatory and primary title field.
   - Integrated ignore_links and ignore_version flags for optimized production-grade migration performance.
