### PR TITLE
Feat/enhancing the my audits tracker UI to display pending response timestamps and creation date on hover

### DIFF
--- a/audit_management/audit_management/doctype/my_audits/my_audits.js
+++ b/audit_management/audit_management/doctype/my_audits/my_audits.js
@@ -2227,11 +2227,14 @@ function render_interactive_tracker(frm, can_edit) {
   // Modern SVG Chevron instead of -->
   const arrow_svg = `<svg class="modern-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin: 0 4px;"><polyline points="9 18 15 12 9 6"></polyline></svg>`;
 
+  // Format date helper
+  const fmt_date = (d) => (d ? frappe.datetime.str_to_user(d) : "");
+
   // 2. Build the HTML wrapper
   let html = `
-        <div class="custom-interactive-tracker-wrapper modern-audit-tracker" style="display: flex; align-items: center; gap: 4px; width: 100%;">
+        <div class="custom-interactive-tracker-wrapper modern-audit-tracker" style="display: flex; align-items: center; gap: 4px; width: 100%; flex-wrap: wrap;">
             
-            <div class="modern-pill pill-audit-team" data-tooltip="Internal Audit Department">
+            <div class="modern-pill pill-audit-team" data-tooltip="Internal Audit Department | Created: ${fmt_date(frm.doc.creation)}">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 6px;"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
                 AUDIT TEAM
             </div>
@@ -2255,10 +2258,18 @@ function render_interactive_tracker(frm, can_edit) {
     // Get the best available name for the tooltip
     let emp_name =
       row.employee_name || row.employee || row.user_id || "Unassigned";
+    
+    // Prepare time info
+    let time_info = "";
+    if (row.status === "Pending" && row.pending_time) {
+      time_info = ` | Pending Since: ${fmt_date(row.pending_time)}`;
+    } else if (row.status === "Responded" && row.response_time) {
+      time_info = ` | Responded: ${fmt_date(row.response_time)}`;
+    }
 
     html += `
             <div class="stage-pill-container sortable-item" style="display: flex; align-items: center; cursor: ${can_edit ? "grab" : "not-allowed"};">
-                <div class="modern-pill ${pill_class}" data-tooltip="${emp_name}">
+                <div class="modern-pill ${pill_class}" data-tooltip="${emp_name}${time_info}">
                     ${row.stage_name}
                 </div>
                 ${arrow_svg}

--- a/audit_management/audit_management/doctype/my_audits/my_audits.js
+++ b/audit_management/audit_management/doctype/my_audits/my_audits.js
@@ -51,6 +51,24 @@ frappe.ui.form.on("My Audits", {
   },
 
   refresh: function (frm) {
+    // 1. Inject Creation/Closing Date into Header
+    if (!frm.is_new() && frm.doc.creation) {
+      setTimeout(() => {
+        let header_status = frm.page.wrapper.find(".indicator-pill").first();
+        if (header_status.length > 0 && frm.page.wrapper.find(".date-tag").length === 0) {
+          let date_html = `<span class="date-tag" style="margin-left: 10px; font-size: 12px; color: #6c757d; font-weight: 500;">`;
+          date_html += `Created: ${frappe.datetime.str_to_user(frm.doc.creation)}`;
+          
+          if (frm.doc.status === "Close" && frm.doc.modified) {
+            date_html += ` | Closed: ${frappe.datetime.str_to_user(frm.doc.modified)}`;
+          }
+          
+          date_html += `</span>`;
+          header_status.after(date_html);
+        }
+      }, 500);
+    }
+    
     // Filter branch (Audit Level) based on the current user's division
     frm.set_query("emp_branch", function () {
       return {


### PR DESCRIPTION
* Enhanced Status Tracking Tooltips: Updated the status tracker in the intro section to display specific timestamps (e.g., "Pending Since"
     or "Responded At") when hovering over each audit stage pill.
   * Audit Lifecycle Header: Added a dynamic date display in the document header next to the status indicator.
   * Creation & Closure Visibility: The header now automatically shows the record's Creation Date and, if the audit query is marked as
     "Close," it additionally displays the Closing Date.
   * UI Stability: These updates are injected via safe, non-destructive DOM manipulation in the refresh event, ensuring existing business
     logic remains completely intact.
