### PR TITLE
feat:Test Fake Responded Status Cleanup Patch

### DIFF
--- a/audit_management/patches.txt
+++ b/audit_management/patches.txt
@@ -13,3 +13,4 @@ audit_management.patches.migrate_production_data_v4
 audit_management.patches.migrate_hardcoded_to_child_table
 audit_management.patches.update_audit_level_branch_fields
 audit_management.patches.fix_status_mispelling
+audit_management.patches.fix_fake_responded_status

--- a/audit_management/patches/fix_fake_responded_status.py
+++ b/audit_management/patches/fix_fake_responded_status.py
@@ -1,0 +1,64 @@
+import frappe
+
+def execute():
+    """
+    Patch to fix incorrect 'Responded' status.
+    Converts 'Responded' -> 'No Response' if:
+    - Status is 'Responded'
+    - Response is empty/blank
+    - pending_time exists
+    """
+    
+    # Mapping for legacy field synchronization
+    mapping = {
+        "BM": "bm",
+        "DH": "dh",
+        "COM": "com",
+        "RM": "rm",
+        "ROM": "rom",
+        "ZM": "zm",
+        "ZOM": "zom",
+        "GM": "gm",
+        "HR": "hr",
+        "CHRO": "chro",
+        "COO": "coo",
+        "CFO": "cfo",
+        "CEO": "ceo",
+    }
+    
+    # Fetch all My Audits documents
+    audit_docs = frappe.get_all("My Audits", pluck="name")
+    
+    count = 0
+    for docname in audit_docs:
+        doc = frappe.get_doc("My Audits", docname)
+        updated = False
+        
+        for row in doc.audit_stages:
+            # Check conditions for corruption
+            if (row.status == "Responded" and 
+                (not row.response or not str(row.response).strip()) and 
+                row.pending_time):
+                
+                # 1. Update child table
+                row.status = "No Response"
+                
+                # 2. Sync to legacy hardcoded fields
+                prefix = mapping.get((row.stage_name or "").strip().upper())
+                if prefix:
+                    doc.set(f"{prefix}_user_status", "No Response")
+                    doc.set(f"{prefix}_response_box", None)
+                    
+                updated = True
+                frappe.log_error(
+                    title="Patch Fix: Status Corrected",
+                    message=f"Audit: {docname}, Stage: {row.stage_name}, User: {row.user_id}, Row ID: {row.name}"
+                )
+        
+        if updated:
+            # Save without triggering unnecessary validations
+            doc.save(ignore_permissions=True)
+            count += 1
+            
+    frappe.db.commit()
+    frappe.logger().info(f"Patch complete. {count} audit records updated.")


### PR DESCRIPTION
- Created test corruption scenario for ZM and HR stages
- Manually set status as Responded with blank response data
- Added pending time to simulate incorrect workflow state
- Verified patch converts fake Responded records to No Response
- Confirmed tracker, legacy sync, and response cleanup behavior working correctly