### PR TITLE
Feat/fix fake responded statuses in audit stages patch

### DIFF
--- a/audit_management/audit_management/doctype/my_audits/my_audits.js
+++ b/audit_management/audit_management/doctype/my_audits/my_audits.js
@@ -2827,6 +2827,18 @@ function render_interactive_tracker(frm, can_edit) {
 
       // Initialize tooltips
       frm.page.wrapper.find('[data-toggle="tooltip"]').tooltip();
+
+      // Ensure settings button click works
+      let settings_icon = document.getElementById("edit-tracker-settings");
+      if (settings_icon) {
+        settings_icon.onclick = function () {
+          if (typeof open_stages_modal === "function") {
+            open_stages_modal(frm);
+          } else {
+            frm.trigger("open_stages_modal");
+          }
+        };
+      }
     }
   }, 600);
 
@@ -2861,15 +2873,6 @@ function render_interactive_tracker(frm, can_edit) {
         });
       },
     });
-
-    setTimeout(() => {
-      let settings_icon = document.getElementById("edit-tracker-settings");
-      if (settings_icon) {
-        settings_icon.onclick = function () {
-          open_stages_modal(frm);
-        };
-      }
-    }, 100);
   }
 }
 

--- a/audit_management/patches/fix_fake_responded_status.py
+++ b/audit_management/patches/fix_fake_responded_status.py
@@ -1,15 +1,17 @@
 import frappe
 
+
 def execute():
     """
     Patch to fix incorrect 'Responded' status.
+
     Converts 'Responded' -> 'No Response' if:
     - Status is 'Responded'
-    - Response is empty/blank
-    - pending_time exists
+    - Response is empty / blank / HTML empty
+    - No attachment exists
     """
-    
-    # Mapping for legacy field synchronization
+
+    # Mapping for legacy hardcoded fields
     mapping = {
         "BM": "bm",
         "DH": "dh",
@@ -25,42 +27,83 @@ def execute():
         "CFO": "cfo",
         "CEO": "ceo",
     }
-    
-    # Fetch all My Audits documents
+
+    # Fetch all My Audits docs
     audit_docs = frappe.get_all("My Audits", pluck="name")
-    
+
     count = 0
+
     for docname in audit_docs:
         doc = frappe.get_doc("My Audits", docname)
-        updated = False
-        
+
         for row in doc.audit_stages:
-            # Check conditions for corruption
-            if (row.status == "Responded" and 
-                (not row.response or not str(row.response).strip()) and 
-                row.pending_time):
-                
-                # 1. Update child table
-                row.status = "No Response"
-                
-                # 2. Sync to legacy hardcoded fields
-                prefix = mapping.get((row.stage_name or "").strip().upper())
-                if prefix:
-                    doc.set(f"{prefix}_user_status", "No Response")
-                    doc.set(f"{prefix}_response_box", None)
-                    
-                updated = True
-                frappe.log_error(
-                    title="Patch Fix: Status Corrected",
-                    message=f"Audit: {docname}, Stage: {row.stage_name}, User: {row.user_id}, Row ID: {row.name}"
+
+            # Normalize response text
+            response_text = (row.response or "").strip()
+
+            # Detect fake / empty responses
+            is_empty_response = (
+                not response_text
+                or response_text in [
+                    "<p><br></p>",
+                    "<div><br></div>",
+                    "<p></p>",
+                    "<div></div>",
+                ]
+            )
+
+            # Check corruption condition
+            if (
+                row.status == "Responded"
+                and is_empty_response
+                and not row.attachment
+            ):
+
+                # -----------------------------------
+                # 1. Update Child Table Directly
+                # -----------------------------------
+                frappe.db.set_value(
+                    "Audit Items",
+                    row.name,
+                    {
+                        "status": "No Response",
+                        "response": None,
+                    },
+                    update_modified=False,
                 )
-        
-        if updated:
-            doc.flags.ignore_validate = True
-            doc.flags.ignore_mandatory = True
-            doc.flags.ignore_version = True
-            doc.db_update()
-            count += 1
-            
+
+                # -----------------------------------
+                # 2. Sync Legacy Hardcoded Fields
+                # -----------------------------------
+                prefix = mapping.get(
+                    (row.stage_name or "").strip().upper()
+                )
+
+                if prefix:
+                    frappe.db.set_value(
+                        "My Audits",
+                        doc.name,
+                        {
+                            f"{prefix}_user_status": "No Response",
+                            f"{prefix}_response_box": None,
+                        },
+                        update_modified=False,
+                    )
+
+                count += 1
+
+                frappe.log_error(
+                    title="Patch Fix: Fake Responded Corrected",
+                    message=(
+                        f"Audit: {docname}\n"
+                        f"Stage: {row.stage_name}\n"
+                        f"User: {row.user_id}\n"
+                        f"Row ID: {row.name}"
+                    ),
+                )
+
     frappe.db.commit()
-    frappe.logger().info(f"Patch complete. {count} audit records updated.")
+
+    frappe.logger().info(
+        f"Patch complete. {count} audit stage records updated."
+    )


### PR DESCRIPTION
Added production-safe patch to correct incorrect Responded statuses
Converted fake Responded entries to No Response when no actual response or attachment exists
Added support for empty HTML rich text responses (<p><br></p>, etc.)
Synced both child table (Audit Items) and legacy hardcoded fields
Replaced document save flow with direct frappe.db.set_value() updates to avoid validation failures during migration
Prevented accidental modification of genuine responded stages with attachments